### PR TITLE
Add PlayerStatsSO

### DIFF
--- a/Assets/ScriptableObjects/PlayerStats.asset
+++ b/Assets/ScriptableObjects/PlayerStats.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 071afeca15fd4d61820df055ccbe9104, type: 3}
+  m_Name: PlayerStats
+  m_EditorClassIdentifier:
+  elevationSpeed: 10
+  elevateAccelerationTime: 0.2
+  elevateDecelerationTime: 0.2
+  maxElevation: 15
+  maxDepression: 10
+  horizontalRotationSpeed: 20
+  horizontalAccelerationTime: 0.05
+  horizontalDecelerationTime: 0.3
+  baseCrosshairScaleMultiplier: 3
+  firstZoomFov: 90
+  secondZoomMult: 3
+  thirdZoomMult: 6
+  firstZoomSpeed:
+    horizontal: 15
+    vertical: 20
+  secondZoomSpeed:
+    horizontal: 4.5
+    vertical: 4.5
+  thirdZoomSpeed:
+    horizontal: 1.3
+    vertical: 1.3

--- a/Assets/ScriptableObjects/PlayerStats.asset.meta
+++ b/Assets/ScriptableObjects/PlayerStats.asset.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faeeaef4d6794b3e819f8125198d5c13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/PlayerStatsSO.cs
+++ b/Assets/ScriptableObjects/PlayerStatsSO.cs
@@ -1,0 +1,36 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public struct ZoomSpeedPair
+{
+    public float horizontal;
+    public float vertical;
+}
+
+[CreateAssetMenu(menuName = "Data/Player Stats", fileName = "PlayerStats")]
+public class PlayerStatsSO : ScriptableObject
+{
+    [Header("Cannon movement settings")]
+    public float elevationSpeed = 10f;
+    public float elevateAccelerationTime = 0.2f;
+    public float elevateDecelerationTime = 0.2f;
+    public float maxElevation = 15f;
+    public float maxDepression = 10f;
+
+    [Header("Turret movement settings")]
+    public float horizontalRotationSpeed = 20f;
+    public float horizontalAccelerationTime = 0.05f;
+    public float horizontalDecelerationTime = 0.3f;
+
+    [Header("Zoom Settings")]
+    public float baseCrosshairScaleMultiplier = 3f;
+    public float firstZoomFov = 90f;
+    public float secondZoomMult = 3f;
+    public float thirdZoomMult = 6f;
+
+    [Header("Zoom Speeds")]
+    public ZoomSpeedPair firstZoomSpeed;
+    public ZoomSpeedPair secondZoomSpeed;
+    public ZoomSpeedPair thirdZoomSpeed;
+}

--- a/Assets/ScriptableObjects/PlayerStatsSO.cs.meta
+++ b/Assets/ScriptableObjects/PlayerStatsSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 071afeca15fd4d61820df055ccbe9104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CannonHeightMovement.cs
+++ b/Assets/Scripts/CannonHeightMovement.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class Cannon : MonoBehaviour
 {
     [Header("Player Stats")]
-    [SerializeField] private Player playerStats;
+    [SerializeField] private PlayerStatsSO playerStats;
 
     [Header("Input Event Channel")]
     [SerializeField] private InputEventChannelSO inputEventChannel;

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -12,25 +12,16 @@ public class Player : MonoBehaviour
     [SerializeField] private FireEvent fireEvent;
     [SerializeField] private ChobiAssets.KTP.Wheel_Control_CS wheelControl;
 
-    [Header("Cannon movement settings")]
-    public float elevationSpeed = 10.0f;
-    public float elevateAccelerationTime = 0.2f;
-    public float elevateDecelerationTime = 0.2f;
-    public float maxElevation = 15.0f;
-    public float maxDepression = 10.0f;
-
-    [Header("Turret movement settings")]
-    public float horizontalRotationSpeed = 20.0f;
-    public float horizontalAccelerationTime = 0.05f;
-    public float horizontalDecelerationTime = 0.3f;
+    [Header("Stats")]
+    [SerializeField] public PlayerStatsSO playerStats;
 
     private bool isMovementEnabled = false;
 
     private void Start()
     {
         // init zoom control (for FOV and crosshair)
-        zoomControl.crosshair.scaleFactor = zoomControl.baseCrosshairScaleMultiplier;
-        zoomControl.cinemachineVirtualCamera.m_Lens.FieldOfView = zoomControl.firstZoomFov;
+        zoomControl.crosshair.scaleFactor = playerStats.baseCrosshairScaleMultiplier;
+        zoomControl.cinemachineVirtualCamera.m_Lens.FieldOfView = playerStats.firstZoomFov;
 
         // subscribe to input events
         EnableInputs();

--- a/Assets/Scripts/TurretHorizontalMovement.cs
+++ b/Assets/Scripts/TurretHorizontalMovement.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class Turret : MonoBehaviour
 {
     [Header("Player Stats")]
-    [SerializeField] private Player playerStats;
+    [SerializeField] private PlayerStatsSO playerStats;
 
     [Header("Input Event Channel")]
     [SerializeField] private InputEventChannelSO inputEventChannel;

--- a/Assets/Scripts/ZoomControl.cs
+++ b/Assets/Scripts/ZoomControl.cs
@@ -8,19 +8,13 @@ public class ZoomControl : MonoBehaviour
     private float maxZoomLevel = 2f;
     private float minZoomLevel = 0f;
     private float currentZoomLevel = 0f;
-    private float secondZoomMult = 3f;
-    private float thirdZoomMult = 6f;
-    [SerializeField] public float baseCrosshairScaleMultiplier = 3f;
-    public float CrosshairScaleMultiplier;
-    public float firstZoomFov = 90;
 
-    public Tuple<float, float> firstZoomSpeed = Tuple.Create(15f, 20f);
-    public Tuple<float, float> secondZoomSpeed = Tuple.Create(4.5f, 4.5f);
-    public Tuple<float, float> thirdZoomSpeed = Tuple.Create(1.3f, 1.3f);
+    public float CrosshairScaleMultiplier;
 
     Dictionary<float, Tuple<float, float>> ZoomLevelProperties;
-    Dictionary<float, Tuple<float, float>> ZoomLevelTurretProperties;
+    Dictionary<float, ZoomSpeedPair> ZoomLevelTurretProperties;
     [SerializeField] public Player playerController;
+    [SerializeField] private PlayerStatsSO playerStats;
     [SerializeField] public CinemachineVirtualCamera cinemachineVirtualCamera;
     [SerializeField] public Canvas crosshair;
 
@@ -54,8 +48,8 @@ public class ZoomControl : MonoBehaviour
         CrosshairScaleMultiplier = ZoomLevelProperties[currentZoomLevel].Item1;
         cinemachineVirtualCamera.m_Lens.FieldOfView = CrosshairScaleMultiplier;
         // set turret speed
-        playerController.horizontalRotationSpeed = ZoomLevelTurretProperties[currentZoomLevel].Item1;
-        playerController.elevationSpeed = ZoomLevelTurretProperties[currentZoomLevel].Item2;
+        playerStats.horizontalRotationSpeed = ZoomLevelTurretProperties[currentZoomLevel].horizontal;
+        playerStats.elevationSpeed = ZoomLevelTurretProperties[currentZoomLevel].vertical;
         playerController.UpdateMovementStats();
 
     }
@@ -66,21 +60,21 @@ public class ZoomControl : MonoBehaviour
     void Awake()
     {
         //calculating the requried fov to achieve the right multiplier based in 1 zoom level Fov
-        float secondZoomFov = GetZoomedFOV(firstZoomFov, secondZoomMult);
-        float thirdZoomFov = GetZoomedFOV(firstZoomFov, thirdZoomMult);
-        //zoom properties intialization item 1 is Camara FOV
+        float secondZoomFov = GetZoomedFOV(playerStats.firstZoomFov, playerStats.secondZoomMult);
+        float thirdZoomFov = GetZoomedFOV(playerStats.firstZoomFov, playerStats.thirdZoomMult);
+        //zoom properties intialization item 1 is Camera FOV
         //                              item 2 is crosshair scale multiplier.
         ZoomLevelProperties = new Dictionary<float, Tuple<float, float>>
         {
-            { 0f, Tuple.Create(firstZoomFov, baseCrosshairScaleMultiplier)},
-            { 1f, Tuple.Create(secondZoomFov, baseCrosshairScaleMultiplier*secondZoomMult)},
-            { 2f, Tuple.Create(thirdZoomFov, baseCrosshairScaleMultiplier*thirdZoomMult)}
+            { 0f, Tuple.Create(playerStats.firstZoomFov, playerStats.baseCrosshairScaleMultiplier)},
+            { 1f, Tuple.Create(secondZoomFov, playerStats.baseCrosshairScaleMultiplier * playerStats.secondZoomMult)},
+            { 2f, Tuple.Create(thirdZoomFov, playerStats.baseCrosshairScaleMultiplier * playerStats.thirdZoomMult)}
         };
-        ZoomLevelTurretProperties = new Dictionary<float, Tuple<float, float>>
+        ZoomLevelTurretProperties = new Dictionary<float, ZoomSpeedPair>
         {
-            { 0f, firstZoomSpeed},
-            { 1f, secondZoomSpeed},
-            { 2f, thirdZoomSpeed}
+            { 0f, playerStats.firstZoomSpeed},
+            { 1f, playerStats.secondZoomSpeed},
+            { 2f, playerStats.thirdZoomSpeed}
         };
 
     }


### PR DESCRIPTION
## Summary
- add PlayerStats scriptable object for movement and zoom settings
- load PlayerStats values in Player, Turret, Cannon, and ZoomControl

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6866edc3f1808331801d5cfc04d2c628