### PR TITLE
Add scene-specific TargetBank via ScriptableObject

### DIFF
--- a/Assets/ScriptableObjects/TargetBankSO.cs
+++ b/Assets/ScriptableObjects/TargetBankSO.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Data/Target Bank", fileName = "TargetBank")]
+public class TargetBankSO : ScriptableObject
+{
+    public static TargetBankSO ActiveBank { get; private set; }
+
+    public List<Target> targets = new List<Target>();
+
+    public event Action<Target> OnTargetAdded;
+    public event Action<Target> OnTargetRemoved;
+
+    public void RegisterSceneBank()
+    {
+        ActiveBank = this;
+        Clear();
+    }
+
+    public void AddTarget(Target target)
+    {
+        if (!targets.Contains(target))
+        {
+            targets.Add(target);
+            OnTargetAdded?.Invoke(target);
+        }
+    }
+
+    public void RemoveTarget(Target target)
+    {
+        if (targets.Remove(target))
+        {
+            OnTargetRemoved?.Invoke(target);
+        }
+    }
+
+    public void Clear()
+    {
+        targets.Clear();
+    }
+}

--- a/Assets/Scripts/MapContentBehavior.cs
+++ b/Assets/Scripts/MapContentBehavior.cs
@@ -7,7 +7,6 @@ using UnityEngine.UIElements;
 
 public class MapContentBehavior : MonoBehaviour
 {
-    [SerializeField] public TargetBank targetBank;
     [SerializeField] public RangeFind rangeFind;
     [SerializeField]  private AzimuthFind azimuthFind;
 

--- a/Assets/Scripts/TargetBank.cs
+++ b/Assets/Scripts/TargetBank.cs
@@ -12,9 +12,9 @@ public class TargetBank : MonoBehaviour
     [SerializeField] public AzimuthFind azimuthFind;
     [SerializeField] public MapContentBehavior mapContentBehavior;
     [SerializeField] public Turret turret;
-    public List<Target> targetList;
+    [SerializeField] private TargetBankSO bankData;
 
-    /// Creates a new Target instance and adds it to targetList
+    /// Creates a new Target instance and adds it to the bank
     public Target CreateNewTarget(string name, TargetType targetType, Vector3 worldPosition, string description)
     {
         if (targetPrefab == null)
@@ -35,20 +35,28 @@ public class TargetBank : MonoBehaviour
         }
         // 3. Call Init
 
-        t.Init(name, targetType, go);
+        t.Init(name, targetType, go, rangeFind, azimuthFind, mapContentBehavior);
         t.description = description;
 
         // 4. Add to the list
-        targetList.Add(t);
+        if (bankData != null)
+            bankData.AddTarget(t);
         if (ObjectiveManager.Instance.stages[ObjectiveManager.Instance.currentStageIndex].objective is PressButtonObjective) {
             ObjectiveManager.Instance.stages[ObjectiveManager.Instance.currentStageIndex].objective.Activate();
         }
         return t;
     }
+    private void Awake()
+    {
+        if (bankData != null)
+            bankData.RegisterSceneBank();
+    }
+
     void Start()
     {
         CreateNewTarget("Alpha", TargetType.Enemy, newTargetPositon.position, "test target");
-        turret.RotateToTarget(targetList[0]);
+        if (bankData != null && bankData.targets.Count > 0)
+            turret.RotateToTarget(bankData.targets[0]);
     }
     void Update()
     {

--- a/Assets/Scripts/TargetClass.cs
+++ b/Assets/Scripts/TargetClass.cs
@@ -1,12 +1,9 @@
-using System.Diagnostics;
 using UnityEngine;
-using UnityEngine.Animations;
 using UnityEngine.UI;
 
 public class Target : MonoBehaviour
 {
     public MapContentBehavior mapContentBehavior;
-    public TargetBank targetBank;
     [Header("Target Settings")]
     public string targetName;
     public TargetType type;
@@ -25,18 +22,16 @@ public class Target : MonoBehaviour
 
     [HideInInspector] public bool destroyed = false;
     [HideInInspector] public bool isActive = true;
-    public void Init(string name, TargetType targetType, GameObject targetObject)
+    public void Init(string name, TargetType targetType, GameObject targetObject, RangeFind rangeFind, AzimuthFind azimuthFind, MapContentBehavior mapContent)
     {
-        this.targetBank = transform.parent.GetComponent<TargetBank>();
-        this.mapContentBehavior = FindObjectOfType<MapContentBehavior>();
-
+        this.mapContentBehavior = mapContent;
 
         this.targetName = name;
         this.type = targetType;
         this.targetObject = targetObject;
 
-        this.azimuth = Mathf.RoundToInt(targetBank.azimuthFind.GetAzimuthToTarget(targetObject.transform));
-        this.range = targetBank.rangeFind.GetRangeToTarget(targetObject.transform);
+        this.azimuth = Mathf.RoundToInt(azimuthFind.GetAzimuthToTarget(targetObject.transform));
+        this.range = rangeFind.GetRangeToTarget(targetObject.transform);
 
         if (targetType == TargetType.Enemy)
         {
@@ -52,10 +47,7 @@ public class Target : MonoBehaviour
         }
 
     }
-    private void RotateToThisTarget()
-    {
-        targetBank.turret.RotateToTarget(this);
-    }
+
     private void Start()
     {
     }


### PR DESCRIPTION
## Summary
- introduce `TargetBankSO` ScriptableObject to hold targets and expose events
- refactor `TargetBank` to use `TargetBankSO` and register itself per scene
- decouple `Target` initialization from `TargetBank`
- cleanup unused field in `MapContentBehavior`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686904e0b95c83318dca4cb7dd9314c4