### PR TITLE
Implement runtime TargetBank singleton

### DIFF
--- a/Assets/ScriptableObjects/TargetBankSO.cs
+++ b/Assets/ScriptableObjects/TargetBankSO.cs
@@ -9,8 +9,8 @@ public class TargetBankSO : ScriptableObject
 
     [NonSerialized] public List<Target> targets = new List<Target>();
 
-    public event Action<Target> OnTargetAdded;
-    public event Action<Target> OnTargetRemoved;
+    public Action<Target> OnTargetAdded;
+    public Action<Target> OnTargetRemoved;
 
     public void RegisterSceneBank()
     {

--- a/Assets/ScriptableObjects/TargetBankSO.cs
+++ b/Assets/ScriptableObjects/TargetBankSO.cs
@@ -7,7 +7,7 @@ public class TargetBankSO : ScriptableObject
 {
     public static TargetBankSO ActiveBank { get; private set; }
 
-    public List<Target> targets = new List<Target>();
+    [NonSerialized] public List<Target> targets = new List<Target>();
 
     public event Action<Target> OnTargetAdded;
     public event Action<Target> OnTargetRemoved;
@@ -15,24 +15,16 @@ public class TargetBankSO : ScriptableObject
     public void RegisterSceneBank()
     {
         ActiveBank = this;
-        Clear();
     }
 
     public void AddTarget(Target target)
     {
-        if (!targets.Contains(target))
-        {
-            targets.Add(target);
-            OnTargetAdded?.Invoke(target);
-        }
+        TargetBank.Instance?.AddTarget(target);
     }
 
     public void RemoveTarget(Target target)
     {
-        if (targets.Remove(target))
-        {
-            OnTargetRemoved?.Invoke(target);
-        }
+        TargetBank.Instance?.RemoveTarget(target);
     }
 
     public void Clear()

--- a/Assets/Scripts/NewTargetObjective.cs
+++ b/Assets/Scripts/NewTargetObjective.cs
@@ -22,8 +22,11 @@ public class NewTargetObjective : Objective
 
     public override void Activate()
     {
-        targetBank = FindObjectOfType<TargetBank>();
-        targetBank.CreateNewTarget(targetName, type, targetPosition.position, description);
+        targetBank = TargetBank.Instance;
+        if (targetBank != null)
+            targetBank.CreateNewTarget(targetName, type, targetPosition.position, description);
+        else
+            Debug.LogError("NewTargetObjective: TargetBank instance not found");
         // Called by the ObjectiveManager when this objective becomes active
         enabled = true;
         

--- a/Assets/Scripts/TargetBank.cs
+++ b/Assets/Scripts/TargetBank.cs
@@ -74,7 +74,7 @@ public class TargetBank : MonoBehaviour
         if (newBank == null)
             return;
 
-        TargetBankSO.ActiveBank = newBank;
+        newBank.RegisterSceneBank();
         bankData = newBank;
         runtimeTargets.Clear();
     }


### PR DESCRIPTION
## Summary
- implement a runtime `TargetBank` singleton to persist targets between scenes
- clear and register banks on scene load
- forward `TargetBankSO` Add/Remove calls to singleton

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686922df2b288331b780920e1fe05215