### PR TITLE
Add TargetCreatorUI for new target placement

### DIFF
--- a/Assets/Scripts/TargetCreatorUI.cs
+++ b/Assets/Scripts/TargetCreatorUI.cs
@@ -2,12 +2,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-[System.Serializable]
-public class TargetTypeToggle
-{
-    public Toggle toggle;
-    public TargetType targetType;
-}
 
 public class TargetCreatorUI : MonoBehaviour
 {
@@ -17,7 +11,7 @@ public class TargetCreatorUI : MonoBehaviour
     [SerializeField] private Transform lastLaser;
 
     [Header("Target Type Toggles")]
-    [SerializeField] private List<TargetTypeToggle> targetToggles = new List<TargetTypeToggle>();
+    [SerializeField] private List<TargetTypeToggleInfo> targetToggles = new List<TargetTypeToggleInfo>();
     [SerializeField] private string targetNamePrefix = "Target";
 
     private TargetType? selectedType = null;
@@ -34,12 +28,12 @@ public class TargetCreatorUI : MonoBehaviour
                 lastLaser = go.transform;
         }
 
-        foreach (var pair in targetToggles)
+        foreach (var info in targetToggles)
         {
-            if (pair.toggle == null)
+            if (info == null || info.Toggle == null)
                 continue;
-            TargetType localType = pair.targetType;
-            pair.toggle.onValueChanged.AddListener(isOn => OnToggleChanged(localType, isOn));
+            TargetType localType = info.Type;
+            info.Toggle.onValueChanged.AddListener(isOn => OnToggleChanged(localType, isOn));
         }
     }
 
@@ -73,10 +67,10 @@ public class TargetCreatorUI : MonoBehaviour
         targetBank.CreateNewTarget(name, selectedType.Value, spawnPos, string.Empty);
 
         selectedType = null;
-        foreach (var pair in targetToggles)
+        foreach (var info in targetToggles)
         {
-            if (pair.toggle != null)
-                pair.toggle.SetIsOnWithoutNotify(false);
+            if (info != null && info.Toggle != null)
+                info.Toggle.SetIsOnWithoutNotify(false);
         }
     }
 }

--- a/Assets/Scripts/TargetCreatorUI.cs
+++ b/Assets/Scripts/TargetCreatorUI.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+[System.Serializable]
+public class TargetTypeToggle
+{
+    public Toggle toggle;
+    public TargetType targetType;
+}
+
+public class TargetCreatorUI : MonoBehaviour
+{
+    [Header("Dependencies")]
+    [SerializeField] private RangeDataSO rangeData;
+    [SerializeField] private TargetBank targetBank;
+    [SerializeField] private Transform lastLaser;
+
+    [Header("Target Type Toggles")]
+    [SerializeField] private List<TargetTypeToggle> targetToggles = new List<TargetTypeToggle>();
+    [SerializeField] private string targetNamePrefix = "Target";
+
+    private TargetType? selectedType = null;
+
+    private void Awake()
+    {
+        if (targetBank == null)
+            targetBank = TargetBank.Instance;
+
+        if (lastLaser == null)
+        {
+            GameObject go = GameObject.Find("LastLaser");
+            if (go != null)
+                lastLaser = go.transform;
+        }
+
+        foreach (var pair in targetToggles)
+        {
+            if (pair.toggle == null)
+                continue;
+            TargetType localType = pair.targetType;
+            pair.toggle.onValueChanged.AddListener(isOn => OnToggleChanged(localType, isOn));
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (rangeData != null)
+            rangeData.OnRangeUpdated += HandleRangeUpdated;
+    }
+
+    private void OnDisable()
+    {
+        if (rangeData != null)
+            rangeData.OnRangeUpdated -= HandleRangeUpdated;
+    }
+
+    private void OnToggleChanged(TargetType type, bool isOn)
+    {
+        if (isOn)
+            selectedType = type;
+        else if (selectedType == type)
+            selectedType = null;
+    }
+
+    private void HandleRangeUpdated(int currentRange, bool isSrak, float lastDistance, Vector3 lastPoint)
+    {
+        if (!selectedType.HasValue || targetBank == null)
+            return;
+
+        Vector3 spawnPos = lastLaser != null ? lastLaser.position : lastPoint;
+        string name = $"{targetNamePrefix}_{targetBank.runtimeTargets.Count + 1}";
+        targetBank.CreateNewTarget(name, selectedType.Value, spawnPos, string.Empty);
+
+        selectedType = null;
+        foreach (var pair in targetToggles)
+        {
+            if (pair.toggle != null)
+                pair.toggle.SetIsOnWithoutNotify(false);
+        }
+    }
+}

--- a/Assets/Scripts/TargetCreatorUI.cs.meta
+++ b/Assets/Scripts/TargetCreatorUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06ce77ac6ec94a878722d2db2c00f07e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/TargetTypeToggleInfo.cs
+++ b/Assets/Scripts/TargetTypeToggleInfo.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+[RequireComponent(typeof(Toggle))]
+public class TargetTypeToggleInfo : MonoBehaviour
+{
+    [SerializeField] private Toggle toggle;
+    [SerializeField] private TargetType targetType;
+
+    public Toggle Toggle => toggle;
+    public TargetType Type => targetType;
+
+    private void Reset()
+    {
+        toggle = GetComponent<Toggle>();
+    }
+}

--- a/Assets/Scripts/TargetTypeToggleInfo.cs.meta
+++ b/Assets/Scripts/TargetTypeToggleInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a3762a9d8d7492f9b1e0cdea17b1894
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `TargetCreatorUI` MonoBehaviour to create targets via range finder
- include sample meta file for Unity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68692ff0bf148331a3f067bddf18c021